### PR TITLE
fix: add ffmpeg codec and threads settings to configuration

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -19,6 +19,9 @@ class Settings(BaseSettings):
     SUPABASE_KEY: str = os.getenv("SUPABASE_KEY")
     BUCKET: str = os.getenv("BUCKET")
 
+    FFMPEG_CODEC: str = os.getenv("FFMPEG_CODEC")
+    FFMPEG_THREADS: str = os.getenv("FFMPEG_THREADS")
+
     GOOGLE_CLIENT_ID: str = os.getenv("GOOGLE_CLIENT_ID")
     SECRET_KEY: str = os.getenv("SECRET_KEY")
 

--- a/app/core/reel_generator.py
+++ b/app/core/reel_generator.py
@@ -3,7 +3,7 @@ import tempfile
 
 from moviepy import AudioFileClip, CompositeVideoClip, TextClip, VideoFileClip
 from moviepy.video.tools.subtitles import SubtitlesClip
-
+from app.core.config import settings
 from app.models.reel_generator.color import Color
 from app.models.reel_generator.horizontal_align import HorizontalAlign
 from app.models.reel_generator.vertical_align import VerticalAlign
@@ -128,8 +128,8 @@ class ReelGenerator:
         final_clip.write_videofile(
             output_path,
             fps=self.fps,
-            codec=os.getenv("FFMPEG_CODEC"),
-            threads=os.getenv("FFMPEG_THREADS"),
+            codec=settings.FFMPEG_CODEC,
+            threads=settings.FFMPEG_THREADS,
         )
         return output_path
 


### PR DESCRIPTION
This pull request introduces changes to centralize configuration management and improve maintainability by utilizing the `Settings` class for FFMPEG-related configurations. The most important updates include adding new environment variables to the `Settings` class and refactoring the code to use these variables instead of directly accessing `os.getenv`.

### Configuration centralization:

* [`app/core/config.py`](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bR22-R24): Added `FFMPEG_CODEC` and `FFMPEG_THREADS` as new attributes in the `Settings` class to centralize FFMPEG configuration.

### Code refactoring for maintainability:

* [`app/core/reel_generator.py`](diffhunk://#diff-634e5581239b15279e14d52418316376de03e4cf5ec90e37cbfed86031ca0829L131-R132): Updated `_write_output` method to use `settings.FFMPEG_CODEC` and `settings.FFMPEG_THREADS` instead of directly calling `os.getenv`. This improves consistency and ensures configurations are managed in one place.
* [`app/core/reel_generator.py`](diffhunk://#diff-634e5581239b15279e14d52418316376de03e4cf5ec90e37cbfed86031ca0829L6-R6): Imported `settings` from `app.core.config` to enable the use of centralized configuration variables.