### PR TITLE
fix(audio): add allowed audio extensions for audio file validation

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
 
     ALLOWED_VIDEO_EXTENSIONS: list[str] = [".mp4", ".mov"]
     ALLOWED_MUSIC_EXTENSIONS: list[str] = [".wav"]
+    ALLOWED_AUDIO_EXTENSIONS: list[str] = [".wav"]
     ROLES: list[str] = ["USER", "ADMIN"]
 
     class Config:

--- a/app/services/utils.py
+++ b/app/services/utils.py
@@ -27,7 +27,7 @@ def get_file_duration(file_bytes: bytes, suffix: str = DEFAULT_SUFFIX) -> int:
         tmp_path = tmp.name
 
     try:
-        if suffix in settings.AUDIO_SUFFIXES:
+        if suffix in settings.ALLOWED_AUDIO_EXTENSIONS:
             duration = _duration_wav(tmp_path)
         else:
             with VideoFileClip(tmp_path) as clip:


### PR DESCRIPTION
This pull request makes updates to the file handling logic by introducing a new configuration setting for allowed audio file extensions and ensuring its usage across the codebase.

### Configuration Updates:
* [`app/core/config.py`](diffhunk://#diff-46319cab8aa9cca75fe586084b86c07f241657d02b324944bb7d300ce560039bR30): Added `ALLOWED_AUDIO_EXTENSIONS` to the settings, specifying allowed audio file extensions as `[".wav"]`. This provides a more explicit and centralized configuration for audio file validation.

### Code Updates:
* [`app/services/utils.py`](diffhunk://#diff-4c31c66e8cf9b0cc8e09b623b2ef3dabf602c26af731970ac61c0baf6b0fb2d6L30-R30): Updated the `get_file_duration` function to use `settings.ALLOWED_AUDIO_EXTENSIONS` instead of `settings.AUDIO_SUFFIXES`, ensuring consistency with the newly added configuration.