### PR TITLE
feat: add target language support for text generation and translation

### DIFF
--- a/app/api/v1/endpoints/reel_texts.py
+++ b/app/api/v1/endpoints/reel_texts.py
@@ -13,5 +13,5 @@ def generate_reel_text(
     req: ReelTextRequest,
     _: User = Depends(auth_services.get_current_user),
 ):
-    text = ai_service.generate_reel_text(req.description, req.duration)
+    text = ai_service.generate_reel_text(req.description, req.duration, req.target_lang)
     return ReelTextResponse(text=text)

--- a/app/schemas/reel_text.py
+++ b/app/schemas/reel_text.py
@@ -1,9 +1,12 @@
 from pydantic import BaseModel
 
+from app.models.shared.language import Language
+
 
 class ReelTextRequest(BaseModel):
     description: str
     duration: int
+    target_lang: Language = Language.English
 
 
 class ReelTextResponse(BaseModel):

--- a/app/services/ai.py
+++ b/app/services/ai.py
@@ -7,11 +7,12 @@ from app.models.shared.language import Language
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
-def generate_reel_text(description: str, duration: int) -> str:
+def generate_reel_text(description: str, duration: int, target_lang: Language) -> str:
     prompt = (
         "Tell me ONLY about given topic"
         f"It should last around {duration} seconds. "
         f"Topic: {description}."
+        f"Respond in {target_lang.name}."
     )
     response = openai.chat.completions.create(
         model="gpt-4.1-nano",
@@ -28,22 +29,12 @@ def generate_reel_text(description: str, duration: int) -> str:
     return response.choices[0].message.content.strip()
 
 
-LANGUAGE_CODE_MAP = {
-    Language.English: "english",
-    Language.Spanish: "spanish",
-    Language.French: "french",
-    Language.Italian: "italian",
-    Language.Portuguese: "portuguese",
-    Language.Polish: "polish",
-}
-
-
 def translate_text(
     text: str, source_lang: Language, target_lang: Language
 ) -> dict[str, str]:
     prompt = (
-        f"Translate given text from {LANGUAGE_CODE_MAP[source_lang]}"
-        f" to {LANGUAGE_CODE_MAP[target_lang]}: {text}"
+        f"Translate given text from {source_lang.name}"
+        f" to {target_lang.name}: {text}"
     )
     response = openai.chat.completions.create(
         model="gpt-4.1-nano",


### PR DESCRIPTION
This pull request introduces support for specifying a target language when generating reel text, enhancing multilingual capabilities. The changes include updates to the `generate_reel_text` function, schema adjustments, and refinements in language handling within the AI service.

### Multilingual Support for Reel Text Generation:

* [`app/api/v1/endpoints/reel_texts.py`](diffhunk://#diff-9a0d717a6a382fc55253493d0a8984927a2012b61c22187ff57e427bd188b517L16-R16): Updated the `generate_reel_text` function to accept a `target_lang` parameter, enabling the generation of text in the specified language.
* [`app/schemas/reel_text.py`](diffhunk://#diff-2dfb3911ae5216f3347ac61b0b987944aa0feba2a16dd78216b40792731f5db0R3-R9): Added a `target_lang` field to the `ReelTextRequest` schema with a default value of `Language.English`, ensuring backward compatibility.
* [`app/services/ai.py`](diffhunk://#diff-d0cfc3498c1975a2da9b0adf90334c3fdee1de693a8c808ac3813074997034d6L10-R15): Modified the `generate_reel_text` function to include the `target_lang` parameter in the prompt, allowing the AI model to respond in the desired language.

### Simplification of Language Code Mapping:

* [`app/services/ai.py`](diffhunk://#diff-d0cfc3498c1975a2da9b0adf90334c3fdee1de693a8c808ac3813074997034d6L31-R37): Removed the `LANGUAGE_CODE_MAP` dictionary and updated the `translate_text` function to directly use the `name` attribute of the `Language` enum for source and target language identification.