### PR TITLE
refactor: prevent creation of audio with empty text field

### DIFF
--- a/app/api/v1/endpoints/audios.py
+++ b/app/api/v1/endpoints/audios.py
@@ -53,12 +53,16 @@ def delete_audio(
 
 @router.post("/", response_model=AudioRead, status_code=201)
 def create_audio(
-    audio_file: AudioCreate,
+    audio_info: AudioCreate,
     db: Session = Depends(get_session),
     storage: SupabaseStorageBackend = Depends(get_supabase_storage),
     current_user: User = Depends(auth_services.get_current_user),
 ):
-    audio = crud_audio.create_audio(db, storage, audio_file, current_user.uidd)
+    if audio_info.text is None or audio_info.text.strip() == "":
+        raise HTTPException(
+            status_code=400, detail="Text field cannot be empty"
+        )
+    audio = crud_audio.create_audio(db, storage, audio_info, current_user.uidd)
     if not audio:
         raise HTTPException(status_code=400, detail="Failed to create audio")
     return audio


### PR DESCRIPTION
This pull request includes a small but important change to the `create_audio` function in `app/api/v1/endpoints/audios.py`. The change improves validation by ensuring the `text` field in the `AudioCreate` model is not empty during audio creation.

Key change:

* [`app/api/v1/endpoints/audios.py`](diffhunk://#diff-86a458a8cf2090292a4fc40d14daa882770fe07cb36bad2a6e86c2c11e5087bcL56-R65): Renamed the `audio_file` parameter to `audio_info` and added validation to check that the `text` field in `AudioCreate` is not empty, raising an HTTP 400 error if the field is blank.