### PR TITLE
feat: add refresh token endpoint and update access token handling

### DIFF
--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -38,9 +38,11 @@ def register_user(
 def login_user(user_data: UserLogIn, db: Session = Depends(get_session)):
     return user_services.login_user(user_data, db)
 
+
 @router.post("/refresh", response_model=Token)
 def refresh_token(current_user: User = Depends(auth_services.get_current_user)):
     return user_services.refresh_token(current_user)
+
 
 @router.post("/google/auth", response_model=Token)
 def google_auth(body: UserGoogleAuth, db: Session = Depends(get_session)):

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -38,6 +38,9 @@ def register_user(
 def login_user(user_data: UserLogIn, db: Session = Depends(get_session)):
     return user_services.login_user(user_data, db)
 
+@router.post("/refresh", response_model=Token)
+def refresh_token(current_user: User = Depends(auth_services.get_current_user)):
+    return user_services.refresh_token(current_user)
 
 @router.post("/google/auth", response_model=Token)
 def google_auth(body: UserGoogleAuth, db: Session = Depends(get_session)):

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -34,7 +34,6 @@ def create_access_token(
     else:
         expire = datetime.utcnow() + timedelta(minutes=JWT_EXPIRE_MINUTES)
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
     encoded_jwt = jwt.encode(to_encode, JWT_SECRET, algorithm=JWT_ALGORITHM)
     return AccessToken(token=encoded_jwt, expires_at=expire)
 

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -56,6 +56,13 @@ def register_user(
         expires_at=token_data.expires_at,
     )
 
+def refresh_token(current_user: User) -> Token:
+    token_data = create_access_token({"sub": current_user.email, "uidd": current_user.uidd})
+    return Token(
+        access_token=token_data.token,
+        token_type="bearer",
+        expires_at=token_data.expires_at,
+    )
 
 def login_user(user_data: UserLogIn, db: Session) -> Token:
     user = get_user_by_email(user_data.email, db)

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -56,13 +56,17 @@ def register_user(
         expires_at=token_data.expires_at,
     )
 
+
 def refresh_token(current_user: User) -> Token:
-    token_data = create_access_token({"sub": current_user.email, "uidd": current_user.uidd})
+    token_data = create_access_token(
+        {"sub": current_user.email, "uidd": current_user.uidd}
+    )
     return Token(
         access_token=token_data.token,
         token_type="bearer",
         expires_at=token_data.expires_at,
     )
+
 
 def login_user(user_data: UserLogIn, db: Session) -> Token:
     user = get_user_by_email(user_data.email, db)


### PR DESCRIPTION
This pull request introduces functionality for refreshing authentication tokens and refactors the token creation process to improve clarity and maintainability. The changes add a new endpoint for token refresh, implement the corresponding service logic, and modify the return type of token creation.

### New functionality:

* [`app/api/v1/endpoints/users.py`](diffhunk://#diff-edcf7400f308928d943084e68c5defa3c4ff9fbf0fd4d02451f157082a323bc0R41-R43): Added a new `/refresh` endpoint to allow users to refresh their authentication tokens. This endpoint depends on the `get_current_user` service to verify the current user before issuing a new token.
* [`app/services/user.py`](diffhunk://#diff-6566f3e337f58656024de47074a49c22a2f7eee2f7b9913c49da8fff662fc265R59-R65): Implemented the `refresh_token` service method, which generates a new access token for the current user using their email and unique identifier (`uidd`).

### Code refactoring:

* [`app/services/auth.py`](diffhunk://#diff-f18a357a62f59222e372c1da3a623a3837d6b4dac20636a22bafde9a5f4257aaL37): Refactored `create_access_token` to return an `AccessToken` object instead of a raw JWT string, encapsulating both the token and its expiration time for better type safety and usability.