### PR TITLE
feat: add duration field to audio

### DIFF
--- a/app/api/v1/endpoints/reels.py
+++ b/app/api/v1/endpoints/reels.py
@@ -66,6 +66,12 @@ def generate_reel(
     if db_audio is None:
         raise HTTPException(status_code=404, detail="Audio not found")
 
+    if db_audio.duration > db_movie.duration:
+        raise HTTPException(
+            status_code=400,
+            detail="Audio duration cannot be longer than movie duration",
+        )
+
     movie = storage.download_file(f"{db_movie.id}.{db_movie.type}")
     audio = None
     if reel_req.audio_id:

--- a/app/db/models/audio.py
+++ b/app/db/models/audio.py
@@ -15,6 +15,7 @@ class Audio(SQLModel, table=True):
     voice: int
     language: str
     speed: float
+    duration: int | None = None 
     file_path: str | None = None
     author: int = Field(foreign_key="user.uidd")
     created_at: date = Field(default_factory=date.today)

--- a/app/schemas/audio.py
+++ b/app/schemas/audio.py
@@ -21,7 +21,8 @@ class AudioRead(AudioBase):
     id: int
     created_at: date
     file_path: str
-    srtObject: SrtBase | None = None  # Add this field
+    duration: int | None = None
+    srtObject: SrtBase | None = None
 
     class Config:
         orm_mode = True
@@ -36,6 +37,7 @@ class AudioRead(AudioBase):
             id=audio.id,
             title=audio.title,
             text=audio.text,
+            duration=audio.duration,
             voice=Voice.from_id(audio.voice),
             language=Language(audio.language),
             speed=audio.speed,


### PR DESCRIPTION
This pull request introduces enhancements to the audio handling functionality, including validation for audio duration, new fields in database models and schemas, and refactoring of audio creation and upload processes. The changes aim to improve data integrity and streamline operations.

### Enhancements to audio validation and handling:

* **Validation for audio duration**: Added a check in `generate_reel` to ensure the audio duration does not exceed the movie duration. This prevents mismatched audio and movie lengths during reel generation. (`app/api/v1/endpoints/reels.py`, [app/api/v1/endpoints/reels.pyR69-R74](diffhunk://#diff-3872303b314fb3ebdcf3b572970302edf34d2781827be743a213de5f997c67caR69-R74))
* **Audio duration field**: Introduced a `duration` field in the `Audio` model and its corresponding schema (`AudioRead`) to store and retrieve audio duration. (`app/db/models/audio.py`, [[1]](diffhunk://#diff-a20f6799178458af96c5c42c4324acb0fb8e149a80f0adde724d049fb9e3e7a3R18); `app/schemas/audio.py`, [[2]](diffhunk://#diff-19dcc86781ed6bd4e5e6ab695e2f9821456dc687e6edea05a65d62a4d21664eeL24-R25) [[3]](diffhunk://#diff-19dcc86781ed6bd4e5e6ab695e2f9821456dc687e6edea05a65d62a4d21664eeR40)

### Refactoring audio creation and upload:

* **Audio duration calculation**: Integrated `get_file_duration` utility in `create_audio` to calculate and store the audio duration during creation. (`app/services/audio.py`, [[1]](diffhunk://#diff-70f4267f2ff9bcb9915e84d064f68e414245af3c933486546be2f46059c21902R19) [[2]](diffhunk://#diff-70f4267f2ff9bcb9915e84d064f68e414245af3c933486546be2f46059c21902R98-R114)
* **Optimized audio upload**: Replaced the `_upload_audio` method with direct file upload logic in `create_audio`, simplifying the process and removing redundant code. (`app/services/audio.py`, [[1]](diffhunk://#diff-70f4267f2ff9bcb9915e84d064f68e414245af3c933486546be2f46059c21902L109-R124) [[2]](diffhunk://#diff-70f4267f2ff9bcb9915e84d064f68e414245af3c933486546be2f46059c21902L184-L200)