### PR TITLE
fix: delete associated reels when removing a movie

### DIFF
--- a/app/services/movie.py
+++ b/app/services/movie.py
@@ -13,6 +13,7 @@ from app.schemas.audio import AudioRead
 from app.schemas.movie import MovieCreate, MovieRead, MovieReadBasic
 from app.schemas.reel import ReelWithAudio
 from app.services.utils import get_file_duration
+import app.services.reel as services_reel
 
 
 def _build_movie_read(db_movie):
@@ -170,6 +171,10 @@ def delete_movie(
     db_movie = db.get(Movie, movie_id)
     if not db_movie:
         raise HTTPException(status_code=404, detail="Movie not found")
+
+    for reel in db_movie.reels:
+        services_reel.delete_reel(db, storage, reel.id)
+
     if db_movie.file_path:
         storage.delete_file(f"{db_movie.id}.{db_movie.type}")
     db.delete(db_movie)


### PR DESCRIPTION
This pull request introduces changes to the `app/services/movie.py` file to enhance the handling of associated reels when deleting a movie. The most important updates include importing the `services_reel` module and ensuring that reels linked to a movie are properly deleted during the movie deletion process.

Enhancements to movie deletion:

* [`app/services/movie.py`](diffhunk://#diff-5b5491c526aa6b8e5c0613ce62479d70338365c902b8563f088ad9db3bec0e0eR16): Imported the `services_reel` module to enable access to reel-related functionality.
* [`app/services/movie.py`](diffhunk://#diff-5b5491c526aa6b8e5c0613ce62479d70338365c902b8563f088ad9db3bec0e0eR174-R177): Updated the `delete_movie` function to iterate through `db_movie.reels` and delete each associated reel using `services_reel.delete_reel`. This ensures proper cleanup of related resources when a movie is deleted.