### PR TITLE
refactor: remove unused avatar creation function from user module

### DIFF
--- a/app/services/user.py
+++ b/app/services/user.py
@@ -33,14 +33,11 @@ def register_user(
 
     hashed_password = PasswordHasher.hash_password(user_data.password)
 
-    profile_picture_url = _create_and_upload_avatar(user_data.nick, storage)
-
     user = User(
         email=user_data.email,
         nick=user_data.nick,
         password=hashed_password,
         tiktok_link=user_data.tiktok_link,
-        profile_image_url=profile_picture_url,
         ig_link=user_data.ig_link,
         yt_link=user_data.yt_link,
         fb_link=user_data.fb_link,
@@ -180,38 +177,38 @@ def change_user_password(
     return user
 
 
-def _create_and_upload_avatar(
-    nick: str, storage: SupabaseStorageBackend
-) -> str:
-    size = (256, 256)
-    bg_color = (30, 144, 255)
-    text_color = (255, 255, 255)
-    font_size = 1200
-
-    img = Image.new("RGB", size, bg_color)
-    draw = ImageDraw.Draw(img)
-
-    try:
-        font = ImageFont.truetype("arial.ttf", font_size)
-    except Exception:
-        font = ImageFont.load_default()
-
-    letter = nick[0].upper() if nick else "?"
-    # Use textbbox for Pillow >=10
-    bbox = draw.textbbox((0, 0), letter, font=font)
-    text_width = bbox[2] - bbox[0]
-    text_height = bbox[3] - bbox[1]
-    position = ((size[0] - text_width) // 2, (size[1] - text_height) // 2)
-
-    draw.text(position, letter, fill=text_color, font=font)
-
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    buf.seek(0)
-
-    filename = f"user_avatar_{nick}.png"
-    file_url = storage.upload_file(buf.read(), filename)
-    return file_url
+# def _create_and_upload_avatar(
+#     nick: str, storage: SupabaseStorageBackend
+# ) -> str:
+#     size = (256, 256)
+#     bg_color = (30, 144, 255)
+#     text_color = (255, 255, 255)
+#     font_size = 1200
+#
+#     img = Image.new("RGB", size, bg_color)
+#     draw = ImageDraw.Draw(img)
+#
+#     try:
+#         font = ImageFont.truetype("arial.ttf", font_size)
+#     except Exception:
+#         font = ImageFont.load_default()
+#
+#     letter = nick[0].upper() if nick else "?"
+#     # Use textbbox for Pillow >=10
+#     bbox = draw.textbbox((0, 0), letter, font=font)
+#     text_width = bbox[2] - bbox[0]
+#     text_height = bbox[3] - bbox[1]
+#     position = ((size[0] - text_width) // 2, (size[1] - text_height) // 2)
+#
+#     draw.text(position, letter, fill=text_color, font=font)
+#
+#     buf = io.BytesIO()
+#     img.save(buf, format="PNG")
+#     buf.seek(0)
+#
+#     filename = f"user_avatar_{nick}.png"
+#     file_url = storage.upload_file(buf.read(), filename)
+#     return file_url
 
 
 class PasswordHasher:


### PR DESCRIPTION
This pull request removes the logic for generating and uploading a default avatar for users, simplifying the `register_user` function and marking the `_create_and_upload_avatar` method as unused. This change likely reflects a shift in how profile pictures are handled in the application.

### Simplification of user registration:

* Removed the generation and upload of default avatars in the `register_user` function, eliminating the `profile_picture_url` variable and its associated logic. (`app/services/user.py`, [app/services/user.pyL36-L43](diffhunk://#diff-6566f3e337f58656024de47074a49c22a2f7eee2f7b9913c49da8fff662fc265L36-L43))

### Deprecation of unused avatar creation logic:

* Marked the `_create_and_upload_avatar` method as unused by commenting out its implementation, indicating it is no longer required for user registration. (`app/services/user.py`, [app/services/user.pyL183-R211](diffhunk://#diff-6566f3e337f58656024de47074a49c22a2f7eee2f7b9913c49da8fff662fc265L183-R211))