### PR TITLE
feat: add end timestamp to SRT generation for improved subtitle accuracy

### DIFF
--- a/app/core/reel_generator.py
+++ b/app/core/reel_generator.py
@@ -102,7 +102,7 @@ class ReelGenerator:
     def _load_video_clip(self, movie_path: str):
         clip = VideoFileClip(
             movie_path
-        ).without_audio()  # usuń oryginalny dźwięk
+        ).without_audio()
         clip = clip.resized(height=self.video_height)
         clip = clip.cropped(x_center=clip.w / 2, width=self.video_width)
         return clip

--- a/app/utils/srt.py
+++ b/app/utils/srt.py
@@ -16,6 +16,8 @@ def format_timestamp(seconds: float) -> str:
 def generate_srt(transcription: Transcription) -> str:
     lines = []
     idx = 1
+    last_end_time = 0.0
+
     for segment in transcription.segments:
         for word in segment.words:
             start = format_timestamp(word.start)
@@ -25,5 +27,14 @@ def generate_srt(transcription: Transcription) -> str:
             lines.append(word.text.strip())
             lines.append("")
             idx += 1
+            last_end_time = max(last_end_time, word.end)
 
+    end_start_time = last_end_time
+    start = format_timestamp(end_start_time)
+    end = format_timestamp(end_start_time + 0.3)
+
+    lines.append(f"{idx}")
+    lines.append(f"{start} --> {end}")
+    lines.append("end")
+    lines.append("")
     return "\n".join(lines)


### PR DESCRIPTION
This pull request includes changes to `app/core/reel_generator.py` and `app/utils/srt.py` to improve video processing and subtitle generation functionality. The most significant updates involve refining subtitle generation logic by adding a final timestamp and ensuring proper handling of video clip resizing.

### Video processing improvements:
* [`app/core/reel_generator.py`](diffhunk://#diff-634e5581239b15279e14d52418316376de03e4cf5ec90e37cbfed86031ca0829L105-R105): Removed a redundant comment in the `_load_video_clip` method for cleaner code.

### Subtitle generation enhancements:
* [`app/utils/srt.py`](diffhunk://#diff-084a846fd80abf2d257d4bb2759576401de4d4b4868abf2bbd62c04e113c7abcR19-R20): Added a `last_end_time` variable to track the end time of the last word in the transcription. This ensures accurate calculation of the final timestamp in the `generate_srt` method.
* [`app/utils/srt.py`](diffhunk://#diff-084a846fd80abf2d257d4bb2759576401de4d4b4868abf2bbd62c04e113c7abcR30-R39): Appended a final subtitle segment with a short duration (0.3 seconds) labeled "end" to mark the conclusion of the subtitles.